### PR TITLE
Add link to webring to join or learn more

### DIFF
--- a/views/dashboard.hbs
+++ b/views/dashboard.hbs
@@ -46,7 +46,9 @@
   <div>
     <textarea rows="6" cols="60" id="urls-compatible">
   <a href="https://{{ hostname }}/{{ site.slug_encoded }}/previous">&larr;</a>
-  An IndieWeb Webring 🕸💍
+  An 
+  <a href="https://{{ hostname }}">IndieWeb Webring</a>
+   🕸💍
   <a href="https://{{ hostname }}/{{ site.slug_encoded }}/next">&rarr;</a></textarea>
   </div>
 


### PR DESCRIPTION
Most webrings have a join link that help visitors learn what the webring is about and how to join if that's and option. I am adding a link on this template to that effect.

This does not include validation of this link to be present, but it is something that could be considered (maybe excluding old sites to avoid breaking them)

Example: https://corlaez.com (footer)
Example screenshot:
![image](https://user-images.githubusercontent.com/18663098/189553786-a76e1567-abdf-41f7-8ba1-29c73630989f.png)
